### PR TITLE
added Content-Type header to http json output

### DIFF
--- a/plugins/httpOutput.py
+++ b/plugins/httpOutput.py
@@ -14,6 +14,8 @@ def getConfigSection(url):
 [[outputs.http]]
   url = "{url}"
   data_format = "json"
+[outputs.http.headers]
+  Content-Type = "application/json"
 """.format(url=url)
     return output
 


### PR DESCRIPTION
Fixed HTTP Output according to
[telegraf docs](https://github.com/influxdata/telegraf/blob/master/plugins/outputs/http/README.md) (line 57 to 60)

Tested with `express`, without this update the `request.body` is always `{}` with this the body contains the expected content.

Change-type: patch
Signed-off-by: Peter Makra peter@balena.io