### PR TITLE
Allow x86_64 version

### DIFF
--- a/download.sh
+++ b/download.sh
@@ -6,7 +6,7 @@ download_base="https://dl.influxdata.com/telegraf/releases/"
 case $1 in
     "aarch64") package_file="telegraf-${version}_linux_arm64.tar.gz"
        ;;
-    "rpi") package_file="telegraf-${veriosn}_linux_armhf.tar.gz"
+    "rpi") package_file="telegraf-${version}_linux_armhf.tar.gz"
        ;;
     "amd64") package_file="telegraf-${version}_static_linux_amd64.tar.gz"
        ;;

--- a/download.sh
+++ b/download.sh
@@ -1,14 +1,19 @@
 #!/bin/sh
 
+version="1.22.0"
 outfile="/tmp/telegraf.tar.gz"
 download_base="https://dl.influxdata.com/telegraf/releases/"
 case $1 in
-   aarch64) package_file="telegraf-1.20.2_linux_arm64.tar.gz"
+    "aarch64") package_file="telegraf-${version}_linux_arm64.tar.gz"
        ;;
-    *) package_file="telegraf-1.20.2_linux_armhf.tar.gz"
+    "rpi") package_file="telegraf-${veriosn}_linux_armhf.tar.gz"
+       ;;
+    "amd64") package_file="telegraf-${version}_static_linux_amd64.tar.gz"
+       ;;
+   *) echo >&2 "error: unsupported architecture ($1)"; exit 1 ;;   
 esac
 wget -O "${outfile}" "${download_base}${package_file}"
 
 tar -xvf /tmp/telegraf.tar.gz
-cp ./telegraf-1.20.2/usr/bin/telegraf ./
-rm -rf ./telegraf-1.20.2
+cp ./telegraf-*/usr/bin/telegraf ./
+rm -rf ./telegraf-*


### PR DESCRIPTION
Bumped version of telegraf to 1.22.0 and added x86_64 option.

Change-type: patch